### PR TITLE
Warn when a required secret doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ jobs:
             - name: Check secrets
               id: check
               run: |
-                if ! [[ -n "${{ secrets.GB_API_TOKEN }}" && -n "${{ secrets.GB_API_HOST }}" ]]; then
-                    echo "❌ Missing required secrets: GB_API_TOKEN and/or GB_API_HOST"
+                if ! [[ -n "${{ secrets.GB_API_TOKEN }}" }}" ]]; then
+                    echo "❌ Missing required secret, GB_API_TOKEN"
                     exit 1
+                fi
+                if ! [[ -n "${{ secrets.GB_API_HOST }}" }}" ]]; then
+                    echo "⚠️ Using default value for optional secret, GB_API_HOST"
                 fi
     codeRefs:
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,8 +13,21 @@ on:
         branches:
             - main
 jobs:
+    validate-secrets:
+        runs-on: ubuntu-latest
+        outputs:
+            secrets-available: ${{ steps.check.outputs.available }}
+        steps:
+            - name: Check secrets
+              id: check
+              run: |
+                if ! [[ -n "${{ secrets.GB_API_TOKEN }}" && -n "${{ secrets.GB_API_HOST }}" ]]; then
+                    echo "❌ Missing required secrets: GB_API_TOKEN and/or GB_API_HOST"
+                    exit 1
+                fi
     codeRefs:
         runs-on: ubuntu-latest
+        needs: validate-secrets
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ on:
 jobs:
     validate-secrets:
         runs-on: ubuntu-latest
-        outputs:
-            secrets-available: ${{ steps.check.outputs.available }}
         steps:
             - name: Check secrets
               id: check

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ jobs:
             - name: Check secrets
               id: check
               run: |
-                if ! [[ -n "${{ secrets.GB_API_TOKEN }}" }}" ]]; then
+                if ! [[ -n "${{ secrets.GB_API_TOKEN }}" ]]; then
                     echo "❌ Missing required secret, GB_API_TOKEN"
                     exit 1
                 fi
-                if ! [[ -n "${{ secrets.GB_API_HOST }}" }}" ]]; then
+                if ! [[ -n "${{ secrets.GB_API_HOST }}" ]]; then
                     echo "⚠️ Using default value for optional secret, GB_API_HOST"
                 fi
     codeRefs:


### PR DESCRIPTION
More ergonomics to potentially prevent devs from needing to open an issue like: https://github.com/growthbook/coderefs-action/issues/2